### PR TITLE
opn.requestg_get

### DIFF
--- a/src/migrate_pfsense.py
+++ b/src/migrate_pfsense.py
@@ -407,7 +407,7 @@ if __name__ == '__main__':
         static_leases = get_static_dhcp_leases(dhcpd_interface)
         for lease in static_leases:
             lease["if"] = interface_config["if"]
-            req = opn.requestg_get(f'/services_dhcp_edit.php?if={lease["if"]}' )
+            req = opn.request_get(f'/services_dhcp_edit.php?if={lease["if"]}' )
 
             data = lease
             data["submit"] = "Save"


### PR DESCRIPTION
been attempting to use this pfsense migration script. i ran into an error when pulling in the static dhcp leases.
      
opn.requestg_get was being called, but didn't exist. I changed it to opn.request_get and was able to import the dhcp leases for the LAN interface... however, it still ignores all of my other interfaces. the struggle is real